### PR TITLE
Use HTTPS for secure artifact downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ On the Raspberry PI or BeagleBone Black (after expanding the file system):
 
 Alternatively, you can install using the .deb file:
 
-    curl -O http://adafruit-download.s3.amazonaws.com/adafruitwebide-0.3.12-Linux.deb
+    curl -O https://adafruit-download.s3.amazonaws.com/adafruitwebide-0.3.12-Linux.deb
     sudo dpkg -i adafruitwebide-0.3.12-Linux.deb
     sudo apt-get -f install
 

--- a/release/version.txt
+++ b/release/version.txt
@@ -1,3 +1,3 @@
 0.3.12
-http://adafruit-download.s3.amazonaws.com/webide-0.3.12-update.tar.gz
+https://adafruit-download.s3.amazonaws.com/webide-0.3.12-update.tar.gz
 https://raw.githubusercontent.com/adafruit/Adafruit-WebIDE/alpha/release/changelog.txt

--- a/scripts/install-angstrom.sh
+++ b/scripts/install-angstrom.sh
@@ -68,7 +68,7 @@ echo "Attempting to force reload date and time from ntp server"
 /usr/bin/ntpdate -b -s -u pool.ntp.org
 
 echo "**** Downloading the latest version of the WebIDE ****"
-curl -L http://adafruit-download.s3.amazonaws.com/webide-0.3.12.tar.gz | tar xzf -
+curl -L https://adafruit-download.s3.amazonaws.com/webide-0.3.12.tar.gz | tar xzf -
 
 echo "**** Installing required libraries ****"
 echo "**** (redis-server git avahi-daemon i2c-tools python-smbus openssh-keygen) ****"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -65,7 +65,7 @@ mkdir -p "$WEBIDE_HOME"
 cd "$WEBIDE_ROOT"
 
 echo "**** Downloading the latest version of the WebIDE ****"
-curl -L http://adafruit-download.s3.amazonaws.com/webide-0.3.12.tar.gz | tar xzf -
+curl -L https://adafruit-download.s3.amazonaws.com/webide-0.3.12.tar.gz | tar xzf -
 
 echo "**** Installing required libraries ****"
 echo "**** (redis-server git restartd libcap2-bin avahi-daemon i2c-tools python-smbus) ****"


### PR DESCRIPTION
The artifacts are hosted on S3, so there's an easily available HTTPS endpoint which protects users from MITM attacks.